### PR TITLE
Add libraries that require replacement for `Evals.eval`

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -10,6 +10,9 @@ While being experimental, the Scala community has largely adopted the Scala 2 [D
 
 Here is an incomplete list of libraries that use Scala 2 macros and their migration status:
 
+* [expression-evaluator](https://github.com/plokhotnyuk/expression-evaluator) - not migrated, no replacement for `Evals.eval` 
+* [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala) - not migrated, no replacement for `Evals.eval`
+
 [Contributors welcome!](CONTRIBUTING.md)
 
 ## How to?


### PR DESCRIPTION
Libraries have a couple of use cases where `Evals.eval` was used in compile-time:
1) [for expensive calculations of LUT tables that should happen in compile-time and produce resulting array of primitives](https://github.com/plokhotnyuk/jsoniter-scala/blob/acaded784e95b9c65fe431356ba315bd00aa8363/jsoniter-scala-core/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala#L2390-L2414) (one possible solution provided below in comments, but it leads to code duplication between Scala 2 and Scala 3 codebases)
2) [for injecting user-defined pure functions that configure behavior during macro expansions, so should be instantiated and called in compile-time](https://github.com/plokhotnyuk/jsoniter-scala/blob/acaded784e95b9c65fe431356ba315bd00aa8363/jsoniter-scala-macros/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala#L316) (sort of a principal problem due Scala 2 macros cannot use parameters that are not expressions)
3) [as workaround for getting of Java enumeration values in compile time for Scala 2.11](https://github.com/plokhotnyuk/jsoniter-scala/blob/acaded784e95b9c65fe431356ba315bd00aa8363/jsoniter-scala-macros/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala#L518) (can be easily moved to Scala 2 only codebase)
4) [as workaround for getting of parameter values of macro annotations for cases when it cannot be done by simple pattern matching](https://github.com/plokhotnyuk/jsoniter-scala/blob/acaded784e95b9c65fe431356ba315bd00aa8363/jsoniter-scala-macros/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/JsonCodecMaker.scala#L839) (Scala 2 compiler allows expression in definitions of macro annotations but doesn't reduce them to constants automaticaly)

Any feedback will be greatly appreciated!