### PR TITLE
Add tests for rewrite rules

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,19 @@
+name: Continuous Integration
+on:
+ pull_request:
+   branches: [master]
+ push:
+   branches: [master]
+jobs:
+  rewrites:
+    name: Test Rewrites
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v7
+      - name: "Rewrites 3.0"
+        run: sbt 'set rewrites / migration := "3.0"; rewrites / test'
+      - name: "Rewrites 3.1"
+        run: sbt 'set rewrites / migration := "3.1"; rewrites / test'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.metals/
+target/

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,28 @@
+import org.apache.commons.io.FileUtils
+
+val dottyVersion = "0.25.0-RC2"
+
+val inputDir = settingKey[File]("Directory containing the source files that will be rewitten")
+val outputDir = settingKey[File]("Directory in which the source files are rewritten")
+val checkDir = settingKey[File]("Directory that contains the expected rewritten files")
+val migration = settingKey[String]("Target Scala version - 3.0 or 3.1")
+
+val rewrites = (project in file("rewrites"))
+  .settings(
+    scalaVersion := dottyVersion,
+    migration := "3.0",
+    scalacOptions ++= Seq(s"-source:${migration.value}-migration","-rewrite"),
+    inputDir := baseDirectory.value / s"src/input/scala-${migration.value}",
+    outputDir := target.value / s"src-managed/main/scala-${migration.value}",
+    checkDir := baseDirectory.value / s"src/check/scala-${migration.value}",
+    Compile / sourceGenerators += Def.task { copySources(inputDir.value, outputDir.value) },
+    Test / test := Def.task {
+      new FileChecker(outputDir.value, checkDir.value, state.value.log).run() 
+    }.dependsOn(Compile / compile).value
+  )
+
+def copySources(inputDir: File, outputDir: File): Seq[File] = {
+  if (outputDir.exists) FileUtils.deleteDirectory(outputDir)
+  FileUtils.copyDirectory(inputDir, outputDir)
+  outputDir.listFiles.filter(_.isFile)
+}

--- a/project/FileChecker.scala
+++ b/project/FileChecker.scala
@@ -1,0 +1,68 @@
+import java.io.File
+import scala.io.Source
+import scala.collection.JavaConverters._
+import sbt.util.Logger
+import com.github.difflib.text._
+
+class FileChecker(outputDir: File, checkDir: File, logger: Logger) {
+  private val diffGen = DiffRowGenerator.create()
+    .showInlineDiffs(true)
+    .inlineDiffByWord(true)
+    .oldTag(f => "**")
+    .build()
+
+  def run(): Unit = {
+    val outputFiles = outputDir.listFiles
+      .filter(_.isFile)
+      .map(f => f.getName() -> f)
+      .toMap
+
+    val checkFiles = checkDir.listFiles().filter(_.isFile())
+
+    val initialReport = Report(0, 0)
+
+    val finalReport = checkFiles.foldLeft(initialReport) {
+      (report, checkFile) =>
+        val fileName = checkFile.getName
+        outputFiles.get(fileName) match {
+          case None => report.missingFile(fileName)
+          case Some(outputFile) =>
+            val diff = compare(outputFile, checkFile)
+            if (diff.isEmpty) report.success(fileName)
+            else report.fileDiff(fileName, diff) 
+        }
+    }
+
+    if (finalReport.failed > 0)
+      throw new Exception(s"${finalReport.failed} file checks failed")
+  }
+
+  private def compare(outputFile: File, checkFile: File): Seq[String] = {
+    val diff = diffGen.generateDiffRows(
+      Source.fromFile(outputFile).getLines().toList.asJava,
+      Source.fromFile(checkFile).getLines().toList.asJava
+    )
+    diff.asScala.toSeq
+      .zipWithIndex
+      .filter { case (delta, _) => delta.getTag() != DiffRow.Tag.EQUAL }
+      .map { case (delta, line) => s"line ${line}:" + delta.getOldLine }
+  }
+
+  private case class Report(succeeded: Int, failed: Int) {
+    def missingFile(name: String): Report = {
+      logger.error(s"missing output file $name")
+      Report(succeeded, failed + 1)
+    }
+
+    def fileDiff(name: String, diff: Seq[String]): Report = {
+      logger.error(s"diff in file $name")
+      diff.foreach(logger.error(_))
+      Report(succeeded, failed + 1)
+    }
+
+    def success(name: String): Report = {
+      logger.info(s"no diff in $name")
+      Report(succeeded + 1, failed)
+    }
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,6 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
+
+ThisBuild / libraryDependencies ++= Seq(
+  "org.apache.commons" % "commons-io" % "1.3.2",
+  "io.github.java-diff-utils" % "java-diff-utils" % "4.5"
+)

--- a/rewrites/src/check/scala-3.0/1-keywords.scala
+++ b/rewrites/src/check/scala-3.0/1-keywords.scala
@@ -1,0 +1,5 @@
+object `given` {
+  val `enum` = ???
+
+  def foo = println(`enum`)
+}

--- a/rewrites/src/check/scala-3.0/2-lambdaParam.scala
+++ b/rewrites/src/check/scala-3.0/2-lambdaParam.scala
@@ -1,0 +1,3 @@
+object LambdaParam {
+  val f = { (x: Int) => x * x }
+}

--- a/rewrites/src/check/scala-3.0/3-symbolLitterals.scala
+++ b/rewrites/src/check/scala-3.0/3-symbolLitterals.scala
@@ -1,0 +1,5 @@
+object SymbolLitterals {
+  val values: Map[Symbol, Int] = Map(Symbol("abc") -> 1)
+
+  val abc = values(Symbol("abc"))
+}

--- a/rewrites/src/check/scala-3.0/4-indentArgument.scala
+++ b/rewrites/src/check/scala-3.0/4-indentArgument.scala
@@ -1,0 +1,8 @@
+object IndentArgument {
+  def test(title: String)(body: => Unit) = ???
+  
+  test("my test")
+    {
+    assert(1 == 1)
+  }
+}

--- a/rewrites/src/check/scala-3.0/5-doWhile.scala
+++ b/rewrites/src/check/scala-3.0/5-doWhile.scala
@@ -1,0 +1,9 @@
+object DoWhile {
+  def foo(f: Int => Int): Int = {
+    var i = 0
+    while ({ {
+      i += 1
+    } ; f(i) == 0}) ()
+    i
+  }
+}

--- a/rewrites/src/check/scala-3.0/6-procedure.scala
+++ b/rewrites/src/check/scala-3.0/6-procedure.scala
@@ -1,0 +1,9 @@
+trait Foo {
+  def print(): Unit 
+}
+
+object Bar {
+  def print(): Unit = {
+    println("bar")
+  }
+}

--- a/rewrites/src/check/scala-3.1/7-wildcard.scala
+++ b/rewrites/src/check/scala-3.1/7-wildcard.scala
@@ -1,0 +1,9 @@
+trait Container[A] {
+  def weight: Int
+}
+
+object Container {
+  def compare(x: Container[?], y: Container[?]): Int = {
+    x.weight - y.weight
+  }
+}

--- a/rewrites/src/input/scala-3.0/1-keywords.scala
+++ b/rewrites/src/input/scala-3.0/1-keywords.scala
@@ -1,0 +1,5 @@
+object given {
+  val enum = ???
+
+  def foo = println(enum)
+}

--- a/rewrites/src/input/scala-3.0/2-lambdaParam.scala
+++ b/rewrites/src/input/scala-3.0/2-lambdaParam.scala
@@ -1,0 +1,3 @@
+object LambdaParam {
+  val f = { x: Int => x * x }
+}

--- a/rewrites/src/input/scala-3.0/3-symbolLitterals.scala
+++ b/rewrites/src/input/scala-3.0/3-symbolLitterals.scala
@@ -1,0 +1,5 @@
+object SymbolLitterals {
+  val values: Map[Symbol, Int] = Map('abc -> 1)
+
+  val abc = values('abc)
+}

--- a/rewrites/src/input/scala-3.0/4-indentArgument.scala
+++ b/rewrites/src/input/scala-3.0/4-indentArgument.scala
@@ -1,0 +1,8 @@
+object IndentArgument {
+  def test(title: String)(body: => Unit) = ???
+  
+  test("my test")
+  {
+    assert(1 == 1)
+  }
+}

--- a/rewrites/src/input/scala-3.0/5-doWhile.scala
+++ b/rewrites/src/input/scala-3.0/5-doWhile.scala
@@ -1,0 +1,9 @@
+object DoWhile {
+  def foo(f: Int => Int): Int = {
+    var i = 0
+    do {
+      i += 1
+    } while (f(i) == 0)
+    i
+  }
+}

--- a/rewrites/src/input/scala-3.0/6-procedure.scala
+++ b/rewrites/src/input/scala-3.0/6-procedure.scala
@@ -1,0 +1,9 @@
+trait Foo {
+  def print()
+}
+
+object Bar {
+  def print() {
+    println("bar")
+  }
+}

--- a/rewrites/src/input/scala-3.1/7-wildcard.scala
+++ b/rewrites/src/input/scala-3.1/7-wildcard.scala
@@ -1,0 +1,9 @@
+trait Container[A] {
+  def weight: Int
+}
+
+object Container {
+  def compare(x: Container[_], y: Container[_]): Int = {
+    x.weight - y.weight
+  }
+}


### PR DESCRIPTION
Add tests for the documented rewrite rules.

The `rewrites / test` task will perform these steps:
  - copy the source files from `rewrites/input/`  to `rewrites/target/src-managed/`
  - compile the files in `rewrites/target/src-managed/` with `-source:3.0-migration -rewrite`
  - compare the files in `rewrites/target/src-managed/` with the files in `rewrites/check/`

It is also possible to change the migration version to 3.1 to test the `-source:3.1-migration` rules.