### PR TITLE
Add and test incompatibilities

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v7
-      - name: "Rewrites 3.0"
+      - name: Rewrites 3.0
         run: sbt 'set rewrites / migration := "3.0"; rewrites / test'
-      - name: "Rewrites 3.1"
+      - name: Rewrites 3.1
         run: sbt 'set rewrites / migration := "3.1"; rewrites / test'
+  incompat:
+    name: Test Incompatibilities
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-scala@v7
+      - name: Test Incompatibilities
+        run: sbt '++0.25.0-RC2; incompat / test; ++2.13.3; incompat / test'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .metals/
 target/
+.bloop/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .metals/
 target/
 .bloop/
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,28 +1,82 @@
 import org.apache.commons.io.FileUtils
+import sbt.librarymanagement.CrossVersion
+import xsbti.compile.CompileAnalysis
 
-val dottyVersion = "0.25.0-RC2"
+val scala213 = "2.13.3"
+val dotty = "0.25.0-RC2"
 
 val inputDir = settingKey[File]("Directory containing the source files that will be rewitten")
 val outputDir = settingKey[File]("Directory in which the source files are rewritten")
 val checkDir = settingKey[File]("Directory that contains the expected rewritten files")
 val migration = settingKey[String]("Target Scala version - 3.0 or 3.1")
 
+val CompileBackward = Configuration.of("CompileBackward", "compile-bwd")
+
 val rewrites = (project in file("rewrites"))
   .settings(
-    scalaVersion := dottyVersion,
+    scalaVersion := dotty,
     migration := "3.0",
     scalacOptions ++= Seq(s"-source:${migration.value}-migration","-rewrite"),
     inputDir := baseDirectory.value / s"src/input/scala-${migration.value}",
     outputDir := target.value / s"src-managed/main/scala-${migration.value}",
     checkDir := baseDirectory.value / s"src/check/scala-${migration.value}",
     Compile / sourceGenerators += Def.task { copySources(inputDir.value, outputDir.value) },
-    Test / test := Def.task {
-      new FileChecker(outputDir.value, checkDir.value, state.value.log).run() 
-    }.dependsOn(Compile / compile).value
+    Test / test := {
+      val _ = (Compile / compile).value
+      val fileChecker = new FileChecker(outputDir.value, checkDir.value, streams.value.log)
+      fileChecker.run()
+    }
   )
+
+val incompatSettings = inConfig(CompileBackward)(Defaults.compileSettings) ++ 
+  Seq(
+    scalaVersion := dotty,
+    crossScalaVersions := List(scala213, dotty),
+    Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / s"src/main/scala"),
+    CompileBackward / unmanagedSourceDirectories := Seq(baseDirectory.value / s"src/main/scala-2.13"),
+    CompileBackward / managedClasspath := (managedClasspath in Compile).value,
+    Test / test := {
+      val _ = (Compile / compile).value
+      checkIncompatibility(
+        name.value,
+        scalaVersion.value,
+        (CompileBackward / compile).result.value,
+        streams.value.log
+      )
+    }
+  )
+
+lazy val incompat = (project in file("incompat"))
+  .configs(CompileBackward)
+  .aggregate(typeInfer1)
+
+lazy val typeInfer1 = (project in file("incompat/type-infer-1"))
+  .settings(incompatSettings)
 
 def copySources(inputDir: File, outputDir: File): Seq[File] = {
   if (outputDir.exists) FileUtils.deleteDirectory(outputDir)
   FileUtils.copyDirectory(inputDir, outputDir)
   outputDir.listFiles.filter(_.isFile)
+}
+
+def checkIncompatibility(name: String, scalaVersion: String, compileResult: Result[CompileAnalysis], log: Logger): Unit = {
+  CrossVersion.partialVersion(scalaVersion).foreach {
+    case (0, _) => compileResult match {
+      case Value(_) => 
+        throw new MessageOnlyException(
+          "Compilation has succeeded but failure was expected. " + 
+          s"The '$name' incompatibility is probably fixed, in version $scalaVersion."
+        )
+      case Inc(_) =>
+        log.info(s"$name is incompatible with $scalaVersion")
+    }
+    
+    case (2, _) => compileResult match { 
+      case Value(_) => ()
+      case Inc(_) => 
+        throw new MessageOnlyException(s"$name does not compile with version $scalaVersion anymore.")
+    }
+
+    case _ => ()
+  }
 }

--- a/incompat/type-infer-1/README.md
+++ b/incompat/type-infer-1/README.md
@@ -1,0 +1,13 @@
+This incompatibility is inspired by [endpoints4s](https://github.com/endpoints4s/endpoints4s) from this [original commit](https://github.com/endpoints4s/endpoints4s/commit/2b57a0be3978c92eb89c6ab766eb93b5789c171f#diff-d6fdde1c26979b1076788de7854e2ddc).
+
+As of `0.25.0-RC2` the error message is:
+
+```
+[error] -- [E007] Type Mismatch Error: /home/piquerez/scalacenter/scala-3-migration-guide/incompat/src/main/scala/type-infer.scala:13:64 
+[error] 13 |  def bar(f: Foo[String] => Int): Option[Int] = Option(foo).map(f)
+[error]    |                                                                ^
+[error]    |                                      Found:    (f : Foo[String] => Int)
+[error]    |                                      Required: Foo[Nothing] => Int
+[error] one error found
+[error] (Compile / compileIncremental) Compilation failed
+```

--- a/incompat/type-infer-1/src/main/scala-2.13/type-infer.scala
+++ b/incompat/type-infer-1/src/main/scala-2.13/type-infer.scala
@@ -10,5 +10,5 @@ trait Foo[A]
 object Foo {
   def foo(implicit ctx: Context): Foo[ctx.Out] = ???
 
-  def bar(f: Foo[String] => Int): Option[Int] = Option(foo).map(f) 
+  def bar(f: Foo[String] => Int): Option[Int] = Option(foo).map(f)
 }

--- a/incompat/type-infer-1/src/main/scala-2.13/type-infer.scala
+++ b/incompat/type-infer-1/src/main/scala-2.13/type-infer.scala
@@ -1,0 +1,14 @@
+trait Context { type Out }
+
+object Context {
+  type Aux[A] = Context { type Out = A }
+  implicit val ctx: Aux[String] = ???
+}
+
+trait Foo[A]
+
+object Foo {
+  def foo(implicit ctx: Context): Foo[ctx.Out] = ???
+
+  def bar(f: Foo[String] => Int): Option[Int] = Option(foo).map(f) 
+}

--- a/incompat/type-infer-1/src/main/scala/type-infer.scala
+++ b/incompat/type-infer-1/src/main/scala/type-infer.scala
@@ -1,0 +1,14 @@
+trait Context { type Out }
+
+object Context {
+  type Aux[A] = Context { type Out = A }
+  implicit val ctx: Aux[String] = ???
+}
+
+trait Foo[A]
+
+object Foo {
+  def foo(implicit ctx: Context): Foo[ctx.Out] = ???
+
+  def bar(f: Foo[String] => Int): Option[Int] = Option[Foo[String]](foo).map(f)
+}

--- a/project/FileChecker.scala
+++ b/project/FileChecker.scala
@@ -3,6 +3,7 @@ import scala.io.Source
 import scala.collection.JavaConverters._
 import sbt.util.Logger
 import com.github.difflib.text._
+import sbt.internal.util.MessageOnlyException
 
 class FileChecker(outputDir: File, checkDir: File, logger: Logger) {
   private val diffGen = DiffRowGenerator.create()
@@ -34,7 +35,7 @@ class FileChecker(outputDir: File, checkDir: File, logger: Logger) {
     }
 
     if (finalReport.failed > 0)
-      throw new Exception(s"${finalReport.failed} file checks failed")
+      throw new MessageOnlyException(s"${finalReport.failed} file checks failed")
   }
 
   private def compare(outputFile: File, checkFile: File): Seq[String] = {


### PR DESCRIPTION
This PR is the ground work for tracking the found incompatibilities and their evolutions.

Each incompatibility is described by a project under the `incompat/` directory. The `incompat` project is an aggregation of all incompatibility projects.

Each incompatibility contains:
- a short `README.md` that describes the incompatibility: origin, compiler message, related documentation, related issues...
- a `src/main/scala-2.13` source directory that must compile in Scala 2.13 but not in Dotty
- a proposed solution under `src/main/scala/` that must compile with Scala 2.13 and Dotty

Whatever is the scala version, the `compile` task will compile the `src/main/scala` source directories exclusively.
To compile the `src/main/scala-2.13` you must run `CompileBackward / compile` task.

The `test` task ensure that the incompatibilities are true incompatibilities by performing both compilations. Its result depends on the `scalaVersion`:
  - Scala 2 : both compilation must succeed
  - Dotty: `CompileBackward / compile` must fail and `Compile / compile` must succeed

As soon as an incompatibility is fixed, the `++0.25.0-RC2 incompat / test` will report an error:
```
[error] Compilation has succeeded but failure was expected.
[error] The 'typeInfer1' incompatibility is probably fixed, in version 0.25.0-RC2.
```