### PR TITLE
Complete the list of 3.0-migration and 3.1-migration rewrites

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,8 @@ jobs:
         run: sbt 'set rewrites / migration := "3.0"; rewrites / test'
       - name: Rewrites 3.1
         run: sbt 'set rewrites / migration := "3.1"; rewrites / test'
+      - name: Rewrites 3.1 Deprecation
+        run: sbt 'set rewrites / migration := "3.1-deprecation"; rewrites / test'
   incompat:
     name: Test Incompatibilities
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,12 @@ val rewrites = (project in file("rewrites"))
   .settings(
     scalaVersion := dotty,
     migration := "3.0",
-    scalacOptions ++= Seq(s"-source:${migration.value}-migration", "-rewrite"),
+    scalacOptions ++= { 
+      migration.value match {
+        case "3.1-deprecation" => Seq(s"-source:3.1", "-deprecation", "-rewrite")
+        case version @ ("3.0" | "3.1") => Seq(s"-source:$version-migration", "-rewrite")
+      }
+    },
     inputDir := baseDirectory.value / s"src/input/scala-${migration.value}",
     outputDir := target.value / s"src-managed/main/scala-${migration.value}",
     checkDir := baseDirectory.value / s"src/check/scala-${migration.value}",

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -273,7 +273,11 @@ val f: () => Int = (() => x)
 
 ## Looking ahead to Scala 3.1
 
-Some deprecations have been postponed to 3.1 to facilitate the migration from 2.13 to 3.0 and then from 3.0 to 3.1. However some of the migration rules are already available and you are likely to be able to apply them in your codebase. In this way you get accustomed to the new syntax and prepared for 3.1.
+Some deprecations have been postponed to 3.1 to facilitate the migration from 2.13 to 3.0 and then from 3.0 to 3.1.
+However some of the migration rules are already available and you are likely to be able to apply them in your codebase.
+In this way you get accustomed to the new syntax and prepared for 3.1.
+
+Beware though that some of the `3.1-migration` rewrites break the source compatibility with Scala 2.13.
 
 ### Rule 1 - Replace wildcard type argument '_' with '?'
 

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -253,6 +253,24 @@ object B {
 }
 ```
 
+### Rule 9 - Value Eta-Expansion
+
+Dotty introduces [automatic eta-expansion](https://dotty.epfl.ch/docs/reference/changed-features/eta-expansion-spec.html) which will deprecate the method value syntax `m _`.
+Furthermore Dotty does not allow eta-expansion of values to nullary functions anymore.
+Thus this piece of code is now illegal:
+
+```scala
+val x = 1
+val f: () => Int = x _
+```
+
+Compiling with `dotc -source:3.0-migration -rewrite` can rewrite it to:
+
+```scala
+val x = 1
+val f: () => Int = (() => x)
+```
+
 ## Looking ahead to Scala 3.1
 
 Some deprecations have been postponed to 3.1 to facilitate the migration from 2.13 to 3.0 and then from 3.0 to 3.1. However some of the migration rules are already available and you are likely to be able to apply them in your codebase. In this way you get accustomed to the new syntax and prepared for 3.1.

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -220,6 +220,39 @@ trait Chunk {
 ```
 Auto-application in Scala 3 is covered in detail in [this page](https://dotty.epfl.ch/docs/reference/dropped-features/auto-apply.html) of the Dotty reference.
 
+### Rule 8 - Disambiguate inheritance shadowing
+
+An inherited member cannot shadow an identifier defined in a outer scope anymore.
+For instance, the following code does not compile anymore because the `x` term in C refers to the inherited member from class `A` and shadows the member of the same name in the outer class `B`.
+
+```scala
+class A {
+  val x = 2
+}
+
+object B {
+  val x = 1
+  class C extends A {
+    println(x)
+  }
+}
+```
+
+To avoid any ambiguity you can write `this.x` instead of `x`. The compiler can make this rewrite automatically, under `-source:3.0-migration-rewrite`:
+
+```scala
+class A {
+  val x = 2
+}
+
+object B {
+  val x = 1
+  class C extends A {
+    println(this.x)
+  }
+}
+```
+
 ## Looking ahead to Scala 3.1
 
 Some deprecations have been postponed to 3.1 to facilitate the migration from 2.13 to 3.0 and then from 3.0 to 3.1. However some of the migration rules are already available and you are likely to be able to apply them in your codebase. In this way you get accustomed to the new syntax and prepared for 3.1.

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -415,4 +415,25 @@ def bar(): Int = 3
 val g = (() => bar())
 ```
 
-This rule break the source compatibility with Scala 2.13.
+### Rule 6 - Add `using` clause to pass explicit arguments to context bound
+
+*This rule breaks the source compatibility with Scala 2.13.*
+
+From Scala 3.1 on, context bounds will map to context parameters.
+Thus a `using` clause is needed to pass explicit arguments to them.
+
+Compiling with `dotc -source:3.1-migration -rewrite` rewrites
+
+```scala
+def show[T: Show](value: T): String = ???
+val intShow = new Show[Int] {}
+show(5)(intShow)
+```
+
+Into
+
+```scala
+def show[T: Show](value: T): String = ???
+val intShow = new Show[Int] {}
+show(5)(using intShow)
+```

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -379,3 +379,40 @@ Compiling with `dotc -source:3.1-migration -rewrite` can add it for you automati
 val listOpt: List[Option[Int]] = List(Some(1), None)
 for (case Some(value) <- listOpt) println(value)
 ```
+
+### Rule 5 - Remove method value syntax for eta-expansion
+
+*This rule breaks the source compatibility with Scala 2.13.*
+
+The method value syntax `m _` will no longer be supported in Scala 3.1, since we now have [automatic eta-expansion](https://dotty.epfl.ch/docs/reference/changed-features/eta-expansion-spec.html).
+
+In general you can simply drop the `_` symbol.
+Compiling with `dotc -source:3.1-migration -rewrite` rewrites
+
+```scala
+def foo(x: Int)(y: Int): Int = x + y
+val f = foo _
+```
+
+Into
+
+```scala
+def foo(x: Int)(y: Int): Int = x + y
+val f = foo
+```
+
+In the special case of a nullary method, the rewrite rule transforms
+
+```scala
+def bar(): Int = 3
+val g = bar _
+```
+
+Into
+
+```scala
+def bar(): Int = 3
+val g = (() => bar())
+```
+
+This rule break the source compatibility with Scala 2.13.

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -261,3 +261,30 @@ Compiling with `dotc -source:3.1-migration -rewrite` rewrites it into:
 ```scala
 val f = { (implicit x: Context) => ??? }
 ```
+
+### Rule 3 (deprecation) - Backquote alphanumeric methods used as infix operator
+
+Starting from Scala 3.1, alphanumeric methods should be annotated with `@infix` to be used as infix operators (see [Dotty documentation](https://dotty.epfl.ch/docs/reference/changed-features/operators.html#the-infix-annotation)).
+The `-deprecation` mode of the compiler will warn you foreach infix call of un-annotated methods.
+
+Here, the call of the `difference` method is deprecated:
+
+```scala
+trait MultiSet {
+  def difference(other: MultiSet): MultiSet
+}
+
+def test(s1: MultiSet, s2: MultiSet): MultiSet = 
+  s1 difference s2
+```
+
+The compiler can backquote the method call under the `-source:3.1 -deprecation -rewrite` options.
+
+```scala
+trait MultiSet {
+  def difference(other: MultiSet): MultiSet
+}
+
+def test(s1: MultiSet, s2: MultiSet): MultiSet = 
+  s1 `difference` s2
+```

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -245,3 +245,19 @@ def compare(x: Container[?], y: Container[?]): Int = {
   x.weight - y.weight
 }
 ```
+
+### Rule 2 - Add Parentheses around the implicit parameter of a lambda
+
+*Will be available in Dotty 0.26.0 or Dotty 0.27.0-RC1*
+
+Starting from Scala 3.1, it will be required to enclose the implicit parameter of a lambda in parentheses, making the following Scala 3 code illegal.
+
+```scala
+val f = { implicit x: Context => ??? }
+```
+
+Compiling with `dotc -source:3.1-migration -rewrite` rewrites it into:
+
+```scala
+val f = { (implicit x: Context) => ??? }
+```

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -321,3 +321,43 @@ trait MultiSet {
 def test(s1: MultiSet, s2: MultiSet): MultiSet = 
   s1 `difference` s2
 ```
+
+### Rule 4 - Unchecked pattern bindings
+
+*Will be available in Dotty 0.26.0 or Dotty 0.27.0-RC1*
+
+From Scala 3.1 on, pattern binding will require to be type consistent in order to prevent undesired runtime errors.
+See [Dotty documentation](https://dotty.epfl.ch/docs/reference/changed-features/pattern-bindings.html) for more information on this.
+
+This piece of code compiles in Scala 2.13 and Scala 3.0 but not in Scala 3.1:
+
+```scala
+val list: List[Int] = List(1)
+val head :: _ = list
+```
+
+You can use the `@unchecked` annotation to tell the compiler to ignore that the binding can fail.
+Compiling with `dotc -source:3.1-migration -rewrite` can write it automatically.
+
+```scala
+val list: List[Int] = List(1)
+val head :: _: @unchecked = list
+```
+
+Similarly, in a `for` expression, this piece of code compiles in Scala 2.13 and Scala 3.0 but not in Scala 3.1:
+
+```scala
+val listOpt: List[Option[Int]] = List(Some(1), None)
+for (Some(value) <- listOpt) println(value)
+```
+
+In Scala 2 and Scala 3.0, the elements of `listOpt` are filtered to retain only the value of type `Some` .
+
+In Scala 3.1, this syntax does not induce filtering, but the binding is type checked to prevent runtime errors.
+You can still have the same behavior than Scala 2 by adding the `case` keyword.
+Compiling with `dotc -source:3.1-migration -rewrite` can add it for you automatically.
+
+```scala
+val listOpt: List[Option[Int]] = List(Some(1), None)
+for (case Some(value) <- listOpt) println(value)
+```

--- a/rewrites/src/check/scala-3.0/8-inherit-shadowing.scala
+++ b/rewrites/src/check/scala-3.0/8-inherit-shadowing.scala
@@ -1,0 +1,12 @@
+object InheritShadowing {
+  class A {
+    val x = 2
+  }
+
+  object B {
+    val x = 1
+    class C extends A {
+      println(this.x)
+    }
+  }
+}

--- a/rewrites/src/check/scala-3.0/9-value-eta-expansion.scala
+++ b/rewrites/src/check/scala-3.0/9-value-eta-expansion.scala
@@ -1,0 +1,4 @@
+object ValueEtaExpansion {
+  val x = 1
+  val f: () => Int = (() => x)
+}

--- a/rewrites/src/check/scala-3.1-deprecation/3-alphanumeric-infix.scala
+++ b/rewrites/src/check/scala-3.1-deprecation/3-alphanumeric-infix.scala
@@ -1,0 +1,8 @@
+object AlphanumericInfix {
+  trait MultiSet {
+    def difference(other: MultiSet): MultiSet
+  }
+
+  def test(s1: MultiSet, s2: MultiSet): MultiSet = 
+    s1 `difference` s2
+}

--- a/rewrites/src/check/scala-3.1/2-implicit-lambda-param.scala
+++ b/rewrites/src/check/scala-3.1/2-implicit-lambda-param.scala
@@ -1,0 +1,7 @@
+// TODO: Uncomment on Dotty 0.26.0 or Dotty 0.27.0-RC1
+
+// object ImplicitLambdaParam {
+//   trait Context
+
+//   val f = { implicit ctx: Context => ??? }
+// }

--- a/rewrites/src/check/scala-3.1/4-pattern-binding.scala
+++ b/rewrites/src/check/scala-3.1/4-pattern-binding.scala
@@ -1,0 +1,10 @@
+// TODO Uncomment on Dotty 0.26.0 or Dotty 0.27.0-RC1
+
+// object PatternBinding {
+//   val list: List[Int] = List(1)
+//   val head :: _ = list
+
+//   val listOpt: List[Option[Int]] = List(Some(1), None)
+//   for (Some(value) <- listOpt)
+//     println(value)
+// }

--- a/rewrites/src/check/scala-3.1/5-eta-expansion.scala
+++ b/rewrites/src/check/scala-3.1/5-eta-expansion.scala
@@ -1,0 +1,7 @@
+object EtaExpansion {
+  def foo(x: Int)(y: Int): Int = x + y
+  val f = foo
+
+  def bar(): Int = 3
+  val g = (() => bar())
+}

--- a/rewrites/src/check/scala-3.1/6-context-bound-arg.scala
+++ b/rewrites/src/check/scala-3.1/6-context-bound-arg.scala
@@ -1,0 +1,9 @@
+object ContextBoundArg {
+  trait Show[T]
+  
+  def show[T: Show](value: T): String = ???
+  
+  val intShow = new Show[Int] {}
+  
+  show(5)(using intShow)
+}

--- a/rewrites/src/input/scala-3.0/8-inherit-shadowing.scala
+++ b/rewrites/src/input/scala-3.0/8-inherit-shadowing.scala
@@ -1,0 +1,12 @@
+object InheritShadowing {
+  class A {
+    val x = 2
+  }
+
+  object B {
+    val x = 1
+    class C extends A {
+      println(x)
+    }
+  }
+}

--- a/rewrites/src/input/scala-3.0/9-value-eta-expansion.scala
+++ b/rewrites/src/input/scala-3.0/9-value-eta-expansion.scala
@@ -1,0 +1,4 @@
+object ValueEtaExpansion {
+  val x = 1
+  val f: () => Int = x _
+}

--- a/rewrites/src/input/scala-3.1-deprecation/3-alphanumeric-infix.scala
+++ b/rewrites/src/input/scala-3.1-deprecation/3-alphanumeric-infix.scala
@@ -1,0 +1,8 @@
+object AlphanumericInfix {
+  trait MultiSet {
+    def difference(other: MultiSet): MultiSet
+  }
+
+  def test(s1: MultiSet, s2: MultiSet): MultiSet = 
+    s1 difference s2
+}

--- a/rewrites/src/input/scala-3.1/2-implicit-lambda-param.scala
+++ b/rewrites/src/input/scala-3.1/2-implicit-lambda-param.scala
@@ -1,0 +1,7 @@
+// TODO: Uncomment on Dotty 0.26.0 or Dotty 0.27.0-RC1
+
+// object ImplicitLambdaParam {
+//   trait Context
+
+//   val f = { implicit ctx: Context => ??? }
+// }

--- a/rewrites/src/input/scala-3.1/4-pattern-binding.scala
+++ b/rewrites/src/input/scala-3.1/4-pattern-binding.scala
@@ -1,0 +1,10 @@
+// TODO Uncomment on Dotty 0.26.0 or Dotty 0.27.0-RC1
+
+// object PatternBinding {
+//   val list: List[Int] = List(1)
+//   val head :: _ = list
+
+//   val listOpt: List[Option[Int]] = List(Some(1), None)
+//   for (Some(value) <- listOpt)
+//     println(value)
+// }

--- a/rewrites/src/input/scala-3.1/5-eta-expansion.scala
+++ b/rewrites/src/input/scala-3.1/5-eta-expansion.scala
@@ -1,0 +1,7 @@
+object EtaExpansion {
+  def foo(x: Int)(y: Int): Int = x + y
+  val f = foo _
+
+  def bar(): Int = 3
+  val g = bar _
+}

--- a/rewrites/src/input/scala-3.1/6-context-bound-arg.scala
+++ b/rewrites/src/input/scala-3.1/6-context-bound-arg.scala
@@ -1,0 +1,9 @@
+object ContextBoundArg {
+  trait Show[T]
+  
+  def show[T: Show](value: T): String = ???
+  
+  val intShow = new Show[Int] {}
+  
+  show(5)(intShow)
+}


### PR DESCRIPTION
Document the previously missing `3.0-migration` and `3.1-migration` Dotty rewrite.