### PR TITLE
Rename dotty to Scala 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .metals/
+.vscode/
 target/
 .bloop/
-project/metals.sbt
+**/project/metals.sbt
 
 # Scala-IDE specific
 .scala_dependencies

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ All information you may want to know before starting the migration of your codeb
 ## Content
 
 This repository contains:
- - [`incompat-3.0/`](incompat-3.0/): A corpus of incompatibilities between Scala 2.13 and Scala 3.0 with proposed solution. It also contains the tests of the Dotty migration rewrites for 3.0.
+ - [`incompat-3.0/`](incompat-3.0/): A corpus of incompatibilities between Scala 2.13 and Scala 3.0 with proposed solution. It also contains the tests of the Scala 3 migration rewrites for 3.0.
  - [`incompat-3.1/`](incompat-3.1/): The tests of the Dotty migration rewrites that are already implemented for 3.1.
  - [`docs/`](docs/): The documentation that is published to the [website](https://scalacenter.github.io/scala-3-migration-guide/)
  - [`website/`](website/): The website skeleton powered by [Docusaurus](https://docusaurus.io/en/).
 
 ## Additional Resources
 
-- [The Dotty website](https://dotty.epfl.ch/)
-- [The Dotty example projects](https://github.com/lampepfl/dotty-example-project#getting-your-project-to-compile-with-dotty)
-- [The Dotty community projects](https://github.com/lampepfl/dotty/tree/master/community-build/community-projects)
+- [The Scala 3 website](https://dotty.epfl.ch/)
+- [The Scala 3 example projects](https://github.com/lampepfl/dotty-example-project#getting-your-project-to-compile-with-dotty)
+- [The Scala 3 community projects](https://github.com/lampepfl/dotty/tree/master/community-build/community-projects)
 - [The Scalafix website](https://scalacenter.github.io/scalafix/)
 - [The sbt Cross-Build Manual](https://www.scala-sbt.org/1.x/docs/Cross-Build.html)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -34,9 +34,9 @@ In Scala 2 the signatures are stored in a dedicated format called the Pickle for
 In Scala 3 the story is a bit different because it relies on the TASTy format which is a lot more than a signature layout.
 But, for the purpose of migrating from Scala 2 to Scala 3, only the signatures are useful.
 
-### The Dotty Unpicklers
+### The Scala 3 Unpicklers
 
-The first piece of good news is that the Dotty compiler is already able to read both formats, the Scala 2 Pickle format and the TASTy format, and thus it can type check code that depends on modules or libraries compiled by Scala 2.13 or Scala 3.
+The first piece of good news is that the Scala 3 compiler is already able to read both formats, the Scala 2 Pickle format and the TASTy format, and thus it can type check code that depends on modules or libraries compiled by Scala 2.13 or Scala 3.
 
 ### The Scala 2 TASTy Reader
 
@@ -72,7 +72,7 @@ A macro definition produces bytecode that will be executed at compile time.
 When you depend on a macro definition, the compiler loads the class file that contains it and then calls your macro method to produce the bytecode of your program, that will be executed at runtime.
 
 The Scala 2 macro mechanisms, which were so far available under the `-experimental` flag, are closely tied to the Scala 2 compiler internals.
-Therefore it is impossible to execute them in the Dotty compiler.
+Therefore it is impossible to execute them in the Scala 3 compiler.
 
 In contrast, the Scala 3 macros are based on the TASTy format which is designed for stability and compiler independence.
 We will most certainly have compatibility for the future Scala versions.

--- a/docs/dotty-rewrites.md
+++ b/docs/dotty-rewrites.md
@@ -1,12 +1,12 @@
 ---
 id: dotty-rewrites
-title: Dotty Migration Mode
+title: Scala 3 Migration Mode
 ---
 
-The Dotty compiler, named `dotc`, has been carefully designed to ease the migration from Scala 2.13 to Scala 3.0.
+The Scala 3 compiler, named `dotc`, has been carefully designed to ease the migration from Scala 2.13 to Scala 3.0.
 It comes with a handful of utilities to support you while migrating a Scala 2 codebase to Scala 3.
 
-Try running `dotc`, the Dotty compiler command, to have a glimpse of those utilities:
+Try running `dotc`, the Scala 3 compiler command, to have a glimpse of those utilities:
 
 ``` bash
 $ dotc
@@ -30,7 +30,7 @@ where possible standard options include:
 The `-source:3.0-migration` option makes the compiler forgiving on most of the dropped features, printing warnings in place of errors.
 Each warning is a strong indication that the the compiler is even capable of safely rewriting the deprecated piece of code into a cross-compiling one.
 
-We call this mode the **Dotty Migration Mode**.
+We call this mode the **Scala 3 Migration Mode**.
 
 ## Automatic rewrites
 
@@ -44,13 +44,13 @@ To do so you just need to compile again, this time with the `-source:3.0-migrati
 > - the rewrites are not applied if the code compiles in error
 > - you cannot choose which rules are applied, the compiler runs all of them
 
-You can refer to the [incompatibility table](incompatibilities/table.md) to see the list of Dotty migration rewrites.
+You can refer to the [incompatibility table](incompatibilities/table.md) to see the list of Scala 3 migration rewrites.
 
 ## Error explanations
 
 The `-source:3.0-migration` mode handles many of the changed features but not all of them.
 In some cases you can have remaining errors due to incompatibilities between Scala 2 and Scala 3.
-The Dotty compiler can assist you by providing detailed explanations on them.
+The Scala 3 compiler can assist you by providing detailed explanations on them.
 You can enable this by using `-source:3.0-migration` in combination with `-explain` and `-explain-types`.
 
 > The `-explain` and `-explain-types` options are not limited to the migration mode.

--- a/docs/dotty-syntax-rewrites.md
+++ b/docs/dotty-syntax-rewrites.md
@@ -1,6 +1,6 @@
 ---
 id: dotty-syntax-rewriting
-title: Dotty Syntax Rewriting
+title: Scala 3 Syntax Rewriting
 ---
 ## Introduction
 
@@ -18,10 +18,10 @@ Scala 3 also introduces a new syntax for control structures. The changes
 introduced with this new syntax apply to `if`-expressions, `while`-loops, and
 `for`-expressions.
 
-## Syntax rewriting with the Dotty compiler
+## Syntax rewriting with the Scala 3 compiler
 
 Converting existing code to use the new syntax by hand would be a tedious
-and error-prone task. The good news is that the Dotty compiler can do the
+and error-prone task. The good news is that the Scala 3 compiler can do the
 hard work for us!
 
 There are 4 possible combinations of the syntax options we covered so far,
@@ -169,7 +169,7 @@ case class State(n: Int, minValue: Int, maxValue: Int):
 
 > ### Converting code using a project build
 >
-> Converting source files one by one using the Dotty compiler, is time consuming
+> Converting source files one by one using the Scala 3 compiler, is time consuming
 > (and requires you to specify the class path which can be a hassle). A more
 > efficient way to do this in bulk is to recompile your code as part of your
 > build. For example, if you have an sbt based build, simply add the required

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -3,23 +3,24 @@ id: get-started
 title: Introduction
 ---
 
-Since the announcement that Dotty will eventually become Scala 3, the Dotty contributors and the SIP committee are taking great care of the migration accessibility for everyone: library maintainer, application owner, and teachers.
+Since the announcement that Dotty will become Scala 3, the Scala 3 contributors and the SIP committee are taking great care of the migration accessibility for everyone: library maintainer, application owner, and teachers.
 
 This guide gathers knowledge about the migration. The ultimate goal being to drive the effort of the community toward the release of Scala 3.
 
-All information you may want to know before starting the migration of your codebase should be available in this guide. If not you may want to [contribute](contributing.md).
+All information you may want to know before starting the migration of your codebase should be available in this guide. If you find something's missing, you may want to [contribute](contributing.md).
 
-## Scala 3 (aka Dotty)
+## Scala 3 (formerly known as Dotty)
 
-Dotty is the project name of the new compiler and improved language that will become Scala 3.
+The Scala 3 compiler has been written from the ground up and brings a lot of improvements and removes a number of warths
+and inconsistencies from the Scala 2 language.
 
-Scala 3 is bringing more consistency, more safety and more ergonomics by simplifying, restricting and even dropping some of Scala 2 constructs. It also improves the expressiveness of the language by introducing new types and features. 
+Scala 3 is bringing more consistency, more safety and improved ergonomics by simplifying, restricting and even dropping some of Scala 2 constructs. It also improves the expressiveness of the language by introducing new types and features. 
 
 The compiler has been completely redesigned. In particular the type checker and the type inferencer are different and they do not behave as in Scala 2. The implicit resolution rules have also been reworked.
 
 Last but not least, the macros system from Scala 2 has been dropped and replaced by a new macro system that is safer, more robust and much more stable. It is intended to be forward compatible.
 
-For a complete overview of the changes in Dotty compared to Scala 2, please visit the [Dotty website](https://dotty.epfl.ch/docs/reference/metaprogramming/toc.html).
+For a complete overview of the changes in Scala 3 compared to Scala 2, please visit the [Scala 3 website](https://dotty.epfl.ch/docs/reference/overview.html).
 
 Despite all those changes, Scala 3 is just another Scala version:
 - A large subset of the Scala 2 language still compiles to Scala 3.
@@ -34,17 +35,17 @@ The next section of this guide focuses on the compatibility in the context of th
 
 ## A Tour of the Migration Tools
 
-### The Dotty compiler
+### The Scala 3 compiler
 
-The Dotty compiler itself is a powerful migration tool.
+The Scala 3 compiler itself is a powerful migration tool.
 
 It comes with a migration mode that does its best at compiling Scala 2 code and issues a migration warning wherever the code need some care.
 
 Even more than that, it is able to rewrite your code where necessary.
 
-You can learn more about it in the [`Dotty Migration Mode`](dotty-rewrites.md) section.
+You can learn more about it in the [`Scala 3 Migration Mode`](dotty-rewrites.md) section.
 
-Leveraging this tool, the community has already migrated a significant number of well-known libraries, forming the [community build](https://github.com/lampepfl/dotty/tree/master/community-build/community-projects).
+Leveraging this tool, the community has already migrated a significant number of well-known libraries, forming the [_Scala 3 Community Build_](https://github.com/lampepfl/dotty/tree/master/community-build/community-projects).
 
 ### Scalafix
 
@@ -52,25 +53,25 @@ Leveraging this tool, the community has already migrated a significant number of
 It is the complementary tool to assist the compiler in the migration.
 
 The main advantage of Scalafix is that it can operate in Scala 2.13 so that you can prepare the code before the migration.
-It gives you have control on the applied changes by proceeding incrementally, one rule at a time.
+It gives you control on the applied changes by proceeding incrementally, one rule at a time.
 
 In particular, it might be very convenient for automatic or semi-automatic resolution of the type inference and implicit resolution problems, by adding some types and implicit values in the code.
 
 ### sbt and other build tools
 
-The sbt build tool does already support Dotty and cross-compilation with Scala 2, thanks to the sbt with the [sbt-dotty plugin](https://dotty.epfl.ch/docs/usage/getting-started.html)
+The sbt build tool does already support Scala 3 and cross-compilation with Scala 2, thanks to the [sbt-dotty plugin](https://dotty.epfl.ch/docs/usage/getting-started.html).
 
 It is able to glue all the migration tools together to provide the best migration experience.
 
-Other build tools may also support Dotty and cross-compilation with Scala 2. [Contributions are welcome here!](contributing.md)
+Other build tools may also support Scala 3 and cross-compilation with Scala 2. [Contributions are welcome here!](contributing.md)
 
 ### Metals and other IDEs
 
-Visual Studio Code has its own Dotty Language Server plugin that you can simply configure by running the `sbt launchIDE` task of the `sbt-dotty` plugin.
+Visual Studio Code has its own Scala 3 Language Server plugin that you can simply configure by running the `sbt launchIDE` task of the `sbt-dotty` plugin.
 
-The Dotty support in Metals is on its way, stay tuned to this [Scala Center Update](https://contributors.scala-lang.org/t/metals-and-scala-3/4274).
+Scala 3 support in Metals, including Scala 3 Worksheets, has made significant progress. For more detials, check the relevant [Scala Center Update](https://contributors.scala-lang.org/t/metals-and-scala-3/4274).
 
-The latest version of the Scala plugin for Intellij Idea already has preliminary support for Scala 3.
+The latest version of the Scala plugin for Intellij Idea already has preliminary support, including Scala worksheets, for Scala 3.
 
 ### Scaladex
 
@@ -78,8 +79,8 @@ Check the list of Scala 3 open-source libraries in [Scaladex](https://index.scal
 
 ## Additional Resources
 
-- [The Dotty website](https://dotty.epfl.ch/)
-- [The Dotty example projects](https://github.com/lampepfl/dotty-example-project#getting-your-project-to-compile-with-dotty)
-- [The Dotty community projects](https://github.com/lampepfl/dotty/tree/master/community-build/community-projects)
+- [The Scala 3 website](https://dotty.epfl.ch/)
+- [The Scala 3 example projects](https://github.com/lampepfl/dotty-example-project#getting-your-project-to-compile-with-dotty)
+- [The Scala 3 community projects](https://github.com/lampepfl/dotty/tree/master/community-build/community-projects)
 - [The Scalafix website](https://scalacenter.github.io/scalafix/)
 - [The sbt Cross-Build Manual](https://www.scala-sbt.org/1.x/docs/Cross-Build.html)

--- a/docs/incompatibilities/table.md
+++ b/docs/incompatibilities/table.md
@@ -10,7 +10,7 @@ On rare occasions we can also have runtime incompatibilities, that compile in Sc
 In this page we propose a classification and status of the known incompatibilities.
 The status of an incompatibility is comprised of:
  - Whether the Scala 2.13 compiler produces a deprecation or feature warning on it
- - The existence of a [Dotty migration](../dotty-rewrites.md) rule for it
+ - The existence of a [Scala 3 migration](../dotty-rewrites.md) rule for it
  - The existence of a Scalafix rule that can fix it
 
 > #### Scala 2.13 deprecations and feature warnings
@@ -19,8 +19,8 @@ The status of an incompatibility is comprised of:
 > - Add the `-deprecation` compiler option to locate the usage of deprecated APIs
 > - For locating the feature warnings, you can look for the feature specific `import` and/or add the `-feature` compiler option.
 
-> #### Dotty migration and Scalafix rewrites
-> The Dotty migration mode is fully integrated in the Dotty compiler.
+> #### Scala 3 migration and Scalafix rewrites
+> The Scala 3 migration mode is fully integrated in the Scala 3 compiler.
 > On the contrary, Scalafix is a tool that must be installed and manually configured in your project.
 > However Scalafix has its own advantages:
 > - It runs on Scala 2.13.
@@ -31,9 +31,9 @@ The status of an incompatibility is comprised of:
 
 Some of the old Scala syntax is not supported anymore.
 
-||Scala 2.13|Dotty Migration Rewrite|Scalafix Rule|Comments|
+||Scala 2.13|Scala 3 Migration Rewrite|Scalafix Rule|Comments|
 |--- |--- |--- |--- |--- |
-|[Restricted keywords](syntactic-changes.md#restricted-keywords)||✅||The Dotty rule does not handle all cases|
+|[Restricted keywords](syntactic-changes.md#restricted-keywords)||✅||The Scala 3 rule does not handle all cases|
 |[Procedure syntax](syntactic-changes.md#procedure-syntax)|Deprecation|✅|✅||
 |[Parentheses around lambda parameter](syntactic-changes.md#parentheses-around-lambda-parameter)||✅|✅||
 |[Open brace indentation for passing an argument](syntactic-changes.md#open-brace-indentation-for-passing-an-argument)||✅|||
@@ -45,7 +45,7 @@ Some of the old Scala syntax is not supported anymore.
 
 Some features are dropped to simplify the language.
 
-||Scala 2.13|Dotty Migration Rewrite|Scalafix Rule|Comments|
+||Scala 2.13|Scala 3 Migration Rewrite|Scalafix Rule|Comments|
 |--- |--- |--- |--- |--- |
 |[Symbol literals](dropped-features.md#symbol-literals)|Deprecation|✅|||
 |[`do`-`while` construct](dropped-features.md#do-while-construct)||✅|||
@@ -57,9 +57,9 @@ Some features are dropped to simplify the language.
 
 ## Contextual Abstractions
 
-The redesign of [contextual abstractions](https://dotty.epfl.ch/docs/reference/contextual/motivation.html) in Scala introduces the following incompatibilities:
+The redesign of [contextual abstractions](https://dotty.epfl.ch/docs/reference/contextual/motivation.html) in Scala 3 introduces the following incompatibilities:
 
-||Scala 2.13|Dotty Migration Rewrite|Scalafix Rule|Comments|
+||Scala 2.13|Scala 3 Migration Rewrite|Scalafix Rule|Comments|
 |--- |--- |--- |--- |--- |
 |[Type of implicit def](contextual-abstractions.md#type-of-implicit-definition)|||✅||
 |[Implicit views](contextual-abstractions.md#implicit-views)||||Possible runtime incompatibility|
@@ -70,7 +70,7 @@ The redesign of [contextual abstractions](https://dotty.epfl.ch/docs/reference/c
 
 Some proven features are simplified or restricted to make the language easier and safer to use.
 
-||Scala 2.13|Dotty Migration Rewrite|Scalafix Rule|Comments|
+||Scala 2.13|Scala 3 Migration Rewrite|Scalafix Rule|Comments|
 |--- |--- |--- |--- |--- |
 |[Inheritance shadowing](other-changed-features.md#inheritance-shadowing)||✅|||
 |[Abstract override](other-changed-features.md#abstract-override)|||||
@@ -95,7 +95,7 @@ However we believe these cases are rare or inexistent.
 
 The Scala 3 compiler uses a new type inference algorithm that is better than the old one.
 
-This fundamental change in Dotty leads to a few incompatibilities:
+This fundamental change in Scala 3 leads to a few incompatibilities:
 - The Scala 3 compiler can infer a different type than the one inferred by the Scala 2 compiler
 - The Scala 3 compiler can diagnose a type-checking error where the Scala 2 compiler does not
 

--- a/docs/macros/macros.md
+++ b/docs/macros/macros.md
@@ -42,9 +42,9 @@ If you are already cross-compiling your macro for different versions of Scala 2 
 ## Additional Resources
 
 Documentation:
-- [Dotty Documentation](https://dotty.epfl.ch/docs/reference/metaprogramming/toc.html)
+- [Scala 3 Documentation](https://dotty.epfl.ch/docs/reference/metaprogramming/toc.html)
 - [Macros: The Plan For Scala 3](https://www.scala-lang.org/blog/2018/04/30/in-a-nutshell.html)
-- [Examples](https://github.com/lampepfl/dotty-macro-examples) - a repository with small, self-contained examples of various tasks done with Dotty macros.
+- [Examples](https://github.com/lampepfl/dotty-macro-examples) - a repository with small, self-contained examples of various tasks done with Scala 3 macros.
 
 Talks:
 * [Scala Days - Metaprogramming in Dotty](https://www.youtube.com/watch?v=ZfDS_gJyPTc)

--- a/docs/macros/status.md
+++ b/docs/macros/status.md
@@ -10,10 +10,10 @@ Here is an incomplete list of libraries that use Scala 2 macros and their migrat
 * [expression-evaluator](https://github.com/plokhotnyuk/expression-evaluator) - not migrated, no replacement for `Evals.eval` 
 * [intent](https://github.com/factor10/intent) - compiles to Scala 3
 * [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala) - not migrated, no replacement for `Evals.eval`
-* [minitest](https://github.com/dotty-staging/minitest) - ported to Scala 3 in the Dotty community build but not merged to upstream
-* [munit](https://github.com/dotty-staging/munit) - ported to Scala 3 in the Dotty community build but not merged to upstream
-* [scalatest](https://github.com/dotty-staging/scalatest) - ported to Scala 3 in the Dotty community build but not merged to upstream
-* [scodec-bits](https://github.com/dotty-staging/scodec) - ported to Scala 3 in the Dotty community build but not merged to upstream
+* [minitest](https://github.com/dotty-staging/minitest) - ported to Scala 3 in the _Scala 3 Community Build_ but not merged to upstream
+* [munit](https://github.com/dotty-staging/munit) - ported to Scala 3 in the _Scala 3 Community Build_ but not merged to upstream
+* [scalatest](https://github.com/dotty-staging/scalatest) - ported to Scala 3 in the _Scala 3 Community Build_ but not merged to upstream
+* [scodec-bits](https://github.com/dotty-staging/scodec) - ported to Scala 3 in the _Scala 3 Community Build_ but not merged to upstream
 * [sourcecode](https://github.com/lihaoyi/sourcecode) – cross-compiles to Scala 2 and Scala 3
 * [utest](https://github.com/lihaoyi/utest) – cross-compiles to Scala 2 and Scala 3
 * [xml-interpolator](https://github.com/lampepfl/xml-interpolator) - compiles to Scala 3

--- a/incompat-3.0/README.md
+++ b/incompat-3.0/README.md
@@ -4,10 +4,10 @@ In this folder we track all the found incompatibilities between Scala 2 and Scal
 
 Each incompatibility lives in its own subfolder and sbt subproject. It is described by:
 - a short `README.md` detailing the origin, the compiler message, the related documentation, the related issues and PRs...
-- a `src/main/scala-2.13` source directory that must compile in Scala 2.13 but not in Dotty
-- a proposed solution under `src/main/scala/` that must compile with Scala 2.13 and Dotty
+- a `src/main/scala-2.13` source directory that must compile in Scala 2.13 but not in Scala 3
+- a proposed solution under `src/main/scala/` that must compile with Scala 2.13 and Scala 3
 
-The sbt `<incompat>/test` task ensures both that the `scala-2.13` sources does not compile and that the `scala` sources compiles with Dotty. It will help us maintain an up-to-date view of the incompatibilities because, as Dotty progress towards the release of Scala 3, we expect some of these incompatibilites to be solved at the compiler side.
+The sbt `<incompat>/test` task ensures both that the `scala-2.13` sources does not compile and that the `scala` sources compiles with Scala 3. It will help us maintain an up-to-date view of the incompatibilities because, as Dotty progresses towards the release of Scala 3.0, we expect some of these incompatibilites to be solved at the compiler side.
 
 The `implicitView` incompatibility is different because it is a runtime incompatibility, meaning that the code compiles but the runtime behavior change. In this case the `implicitView/test` task checks that the `scala-2.13` runtime behavior is wrong and that the `scala` runtime behavior is correct.
 
@@ -19,5 +19,5 @@ This set of incompatibilities will be used to track the progress of the migratio
 
 The [Incompatibility Table](https://scalacenter.github.io/scala-3-migration-guide/docs/incompatibilities/table.html) shows the status of those incomaptibility:
   - Does it produce a feature or deprecation warning in 2.13?
-  - Do we have a Dotty migration rewrite?
+  - Do we have a Scala 3 migration rewrite?
   - Do we have a Scalafix rule to handle it?

--- a/incompat-3.0/auto-application/README.md
+++ b/incompat-3.0/auto-application/README.md
@@ -25,9 +25,9 @@ In Scala 3, an unapplied method like this will be eta-expanded into a function.
   def toSeq: Seq[Byte] = bytes
 ```
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
-Compiling with `dotc -source:3.0-migration -rewrite` rewrites it into:
+Compiling with Scala 3 and the `-source:3.0-migration -rewrite` compilation options rewrites it into:
 
 ```scala
 trait Chunk {
@@ -36,7 +36,7 @@ trait Chunk {
 }
 ```
 
-Auto-application is covered in detail in [this page](https://dotty.epfl.ch/docs/reference/dropped-features/auto-apply.html) of the Dotty reference.
+Auto-application is covered in detail in [this page](https://dotty.epfl.ch/docs/reference/dropped-features/auto-apply.html) of the Scala 3 reference documentation.
 
 #### Scalafix rule
 

--- a/incompat-3.0/default-param-variance/README.md
+++ b/incompat-3.0/default-param-variance/README.md
@@ -2,7 +2,7 @@
 
 This incompatibility is inspired by [this commit](https://github.com/dotty-staging/geny/commit/61cc4b5dead21b23f664549dfceb5056a2c7e579) in the  [dotty-staging fork](https://github.com/dotty-staging/geny) of the [lihaoyi/geny](https://github.com/lihaoyi/geny) project.
 
-In Scala 2, default parameters are not subject to variance checks which is unsound and might cause runtime failures, as demonstrated by this [test](https://github.com/lampepfl/dotty/blob/10526a7d0aa8910729b6036ee51942e05b71abf6/tests/neg/variances.scala#L1-L20) in the Dotty repository.
+In Scala 2, default parameters are not subject to variance checks which is unsound and might cause runtime failures, as demonstrated by this [test](https://github.com/lampepfl/dotty/blob/10526a7d0aa8910729b6036ee51942e05b71abf6/tests/neg/variances.scala#L1-L20) in the Scala 3 repository.
 
 Scala 3 does not permit this anymore.
 

--- a/incompat-3.0/do-while/README.md
+++ b/incompat-3.0/do-while/README.md
@@ -13,9 +13,9 @@ do {
 } while (f(i) == 0)
 ```
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
-When compiled with `dotc` and the `-source:3.0-migration -rewrite` options it is rewritten into. 
+When compiled with Scala 3 and the `-source:3.0-migration -rewrite` options it is rewritten into. 
 
 ```scala
 while ({ {

--- a/incompat-3.0/early-initializer/README.md
+++ b/incompat-3.0/early-initializer/README.md
@@ -13,7 +13,7 @@ object Foo extends {
 } with Bar
 ```
 
-The Dotty compiler produces the following error messages:
+The Scala 3 compiler produces the following error messages:
 
 ```
 -- Error: src/main/scala/early-initializer.scala:6:19 

--- a/incompat-3.0/implicit-view/README.md
+++ b/incompat-3.0/implicit-view/README.md
@@ -14,7 +14,7 @@ def pretty[A](a: A)(implicit ev: A => Pretty): String = {
 }
 ```
 
-The Dotty compiler denies those conversions, except if the migration mode is on.
+The Scala 3 compiler denies those conversions, except if the migration mode is on.
 
 Be aware that, if you don't fix the incompatibility, the compiler would look for another conversion from the outer scope and it may find one.
 It would result in an undesired behavior at runtime.

--- a/incompat-3.0/indent-argument/README.md
+++ b/incompat-3.0/indent-argument/README.md
@@ -18,9 +18,9 @@ test("my test") {
 }
 ```
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
-The Dotty migration rewrite is rather to indent the first line of the block.
+The Scala 3 migration rewrite is to indent the first line of the block.
 
 ```scala
 test("my test")

--- a/incompat-3.0/inheritance-shadowing/README.md
+++ b/incompat-3.0/inheritance-shadowing/README.md
@@ -45,8 +45,8 @@ object B {
 
 To avoid any ambiguity you have to write `this.x` instead of `x`.
 
-#### Dotty migration rule
+#### Scala 3 migration rule
 
-The Dotty compiler can automatically disambiguate the code when called with the `-source:3.0-migration -rewrite` options.
+The Scala 3 compiler can automatically disambiguate the code when called with the `-source:3.0-migration -rewrite` options.
 
 In this case it replaces `println(x)` by `println(this.x)`.

--- a/incompat-3.0/keywords/README.md
+++ b/incompat-3.0/keywords/README.md
@@ -1,6 +1,6 @@
 ## Restricted Keywords
 
-Dotty introduces a number of [keywords](https://dotty.epfl.ch/docs/internals/syntax.html#keywords).
+Scala 3 introduces a number of [keywords](https://dotty.epfl.ch/docs/internals/syntax.html#keywords).
 Some are said _regular_ which means that you cannot use them as identifiers anymore.
 The others are said _soft_, meaning that they are not restricted.
 You can still use the `open` identifier, for instance.
@@ -25,9 +25,9 @@ object given {
 
 There is a straightforward solution which is to backquote the keywords when used as identifiers.
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
-The Dotty compiler can apply this simple rewrite by itself, with the `-source:3.0-migration -rewrite` options:
+The Scala 3 compiler can apply this simple rewrite by itself, with the `-source:3.0-migration -rewrite` options:
 
 ```scala
 object `given` {

--- a/incompat-3.0/lambda-params/README.md
+++ b/incompat-3.0/lambda-params/README.md
@@ -6,9 +6,9 @@ When followed by its type, the parameter of a lambda is now required to be enclo
 val f = { x: Int => x * x }
 ```
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
-When compiled with Dotty and the `-source:3.0-migration -rewrite` option it is rewritten into:
+When compiled with Scala 3 and the `-source:3.0-migration -rewrite` option it is rewritten into:
 
 ```scala
 val f = { (x: Int) => x * x }

--- a/incompat-3.0/procedure-syntax/README.md
+++ b/incompat-3.0/procedure-syntax/README.md
@@ -27,9 +27,9 @@ src/main/scala/procedure-syntax.scala:6:15: procedure syntax is deprecated: inst
               ^
 ```
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
-When compiled with Dotty and the `-source:3.0-migration -rewrite` options, the code is rewritten into:
+When compiled with Scala 3 and the `-source:3.0-migration -rewrite` options, the code is rewritten into:
 
 ```scala
 trait Foo {

--- a/incompat-3.0/symbol-literals/README.md
+++ b/incompat-3.0/symbol-literals/README.md
@@ -19,9 +19,9 @@ It produces a deprecation warning message when compiled in Scala 2.13 and the `-
   val values: Map[Symbol, Int] = Map('abc -> 1)
 ```
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
-Compiling with Dotty and the `-source:3.0-migration -rewrite` options can rewrite the code into:
+Compiling with Scala 3 and the `-source:3.0-migration -rewrite` options can rewrite the code into:
 
 ```scala
 val values: Map[Symbol, Int] = Map(Symbol("abc") -> 1)

--- a/incompat-3.0/type-infer-10/README.md
+++ b/incompat-3.0/type-infer-10/README.md
@@ -11,7 +11,7 @@ As of `0.25.0-RC2` the error message is
 [error]    |                 where:    A$1 is a type in method test with bounds <: A
 ```
 
-In the proposed solution the Dotty compiler reports the following warning:
+In the proposed solution the Scala 3 compiler reports the following warning:
 ```
 [warn] -- Warning: /home/piquerez/scalacenter/scala-3-migration-guide/incompat/type-infer-10/src/main/scala/type-infer.scala:11:21 
 [warn] 11 |      case Executing(observer: Callback[Option[A]]) => notify(observer)

--- a/incompat-3.0/type-of-implicit-def/README.md
+++ b/incompat-3.0/type-of-implicit-def/README.md
@@ -1,9 +1,9 @@
 ## Type Of Implicit Definition
 
-Type of implicit definitions (`val` or `def`) are now required by the Dotty compiler.
+Type of implicit definitions (`val` or `def`) are now required by the Scala 3 compiler.
 They cannot be inferred.
 
-Wherever the type annotation of an implicit definition is missing, the Dotty compiler will print an error message of the form:
+Wherever the type annotation of an implicit definition is missing, the Scala 3 compiler will print an error message of the form:
 
 ```
 -- Error: src/main/scala/type-of-implicit-def.scala:4:15 

--- a/incompat-3.0/value-eta-expansion/README.md
+++ b/incompat-3.0/value-eta-expansion/README.md
@@ -1,7 +1,7 @@
 ## Value eta-expansion
 
-Dotty introduces [automatic eta-expansion](https://dotty.epfl.ch/docs/reference/changed-features/eta-expansion-spec.html) which will deprecate the method value syntax `m _`.
-Furthermore Dotty does not allow eta-expansion of values to nullary functions anymore.
+Scala 3 introduces [automatic eta-expansion](https://dotty.epfl.ch/docs/reference/changed-features/eta-expansion-spec.html) which will deprecate the method value syntax `m _`.
+Furthermore Scala 3 does not allow eta-expansion of values to nullary functions anymore.
 Thus this piece of code is now illegal:
 
 ```scala
@@ -9,7 +9,7 @@ val x = 1
 val f: () => Int = x _
 ```
 
-#### Dotty migration rewrite
+#### Scala 3 migration rewrite
 
 Compiling with `dotc -source:3.0-migration -rewrite` can rewrite it to:
 

--- a/incompat-3.0/wildcard-argument/README.md
+++ b/incompat-3.0/wildcard-argument/README.md
@@ -1,6 +1,6 @@
 ## Wildcard type argument
 
-Dotty cannot reduce the application of a higher-kinded abstract type member to the wildcard argument.
+Scala 3 cannot reduce the application of a higher-kinded abstract type member to the wildcard argument.
 
 For instance:
 
@@ -12,7 +12,7 @@ trait Example {
 }
 ```
 
-Produces the following error when compiled with Dotty:
+Produces the following error when compiled with Scala 3:
 
 ```
 -- [E043] Type Error: /home/piquerez/scalacenter/scala-3-migration-guide/incompat-3.0/existential-type/wildcard-argument/target/src-managed/main/scala/wildcard-argument.scala:4:18 
@@ -22,7 +22,7 @@ Produces the following error when compiled with Dotty:
 ```
 
 We want method `f` to accept sequences of values of type `Foo[A]` with possibly different types of parameter `A`.
-Dotty cannot reduce the application of `Foo` to the wildcard argument `_` because `Foo` is an abstract type member.
+Scala 3 cannot reduce the application of `Foo` to the wildcard argument `_` because `Foo` is an abstract type member.
 One possible solution is to introduce a wrapper class around `Foo`:
 
 ```scala


### PR DESCRIPTION
- Following the announcement that the upcoming change in the
  naming of the Dotty atifacts to Scala [3], this name change
  is applied to the migration guide by renaming Dotty to Scala 3
  where applicable
- A minor update to .gitignore to ignore VCS artifacts
- Resolves #67 