### PR TITLE
Fix "nullary method"

### DIFF
--- a/incompat-30/auto-application/README.md
+++ b/incompat-30/auto-application/README.md
@@ -1,6 +1,6 @@
 ## Auto-application
 
-Auto-application is the syntax of calling a nullary method without passing an empty argument list.
+Auto-application is the syntax of calling an empty-paren method such as `def f(): Int` without passing an empty argument list.
 
 In Scala 3.0, when calling a method defined in Scala 3.0, this syntax is forbidden.
 


### PR DESCRIPTION
The terminology around 0-arity method is not used consistently, and not clear so we should use the term used in 'Programming in Scala', which is _empty-paren_ method.

If we insist on using the jargon, then _nilary_ is the term sometimes used in scala/scala discussions. See for instance https://contributors.scala-lang.org/t/nullary-and-nilary-methods/3756

|                  | Programming in Scala  | scala/scala jargon |
|------------------|-----------------------|--------------------|
| `def foo: Int`   | parameterless methods | nullary method     |
| `def foo(): Int` | empty-paren methods   | nilary method      |

[The great () insert](https://github.com/lampepfl/dotty/pull/2716) where this doc came from doesn't seem to use it this way, so like I said it's inconsistent and best to avoid it for user-facing documentation.