### PR TITLE
Fixed the link to the compatibility reference, which is the…

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -83,7 +83,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle />
           <PromoSection>
-            <Button href={docUrl("compatibility.html", language)}>
+            <Button href={docUrl("general/compatibility.html", language)}>
               Get started
             </Button>
           </PromoSection>


### PR DESCRIPTION
…primary CTA on the Scala 3 Migration guide. Currently it leads to 404, since compatibility.html moved from /docs to /docs/general.