### PR TITLE
Try fix algolia

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,23 +1,23 @@
 ---
-id: introduction
+id: get-started
 title: Introduction
 ---
 Scala 3 is a game changer in terms of compatibility in the Scala ecosystem that will greatly improve the day-to-day experience of every Scala programmer, starting from the migration.
 
 In this section you will learn about the compatibility between Scala 2.13 and Scala 3 at the different stages of the program lifetime. You will find the answer of the following questions:
 
-**[Source Level:](source.md)**
+**[Source Level:](compatibility/source.md)**
 - Is Scala 3 a different language?
 - How hard is it to translate a Scala 2.13 project into Scala 3?
 
-**[Classpath Level:](classpath.md)**
+**[Classpath Level:](compatibility/classpath.md)**
 - Can we use a Scala 2.13 library in Scala 3?
 - Can we use a Scala 3 library in Scala 2.13?
 
-**[Runtime:](runtime.md)**
+**[Runtime:](compatibility/runtime.md)**
 - Is it safe to deploy a Scala 3 program into production?
 - How fast are Scala 3 programs compare to Scala 2.13?
  
-**[Metaprogramming:](metaprogramming.md)**
+**[Metaprogramming:](compatibility/metaprogramming.md)**
 - How will my Scala 2.13 project be affected by the new Scala 3 macros?
 - How can I port my macro libary to Scala 3?

--- a/docs/tutorials/prerequisites.md
+++ b/docs/tutorials/prerequisites.md
@@ -3,7 +3,7 @@ id: prerequisites
 title: Project Prerequisites
 ---
 
-The migration to Scala 3 is made easier thanks to the interoperability between Scala 2.13 and Scala 3, as described in the [Compatibility Reference](../compatibility/introduction.md) page.
+The migration to Scala 3 is made easier thanks to the interoperability between Scala 2.13 and Scala 3, as described in the [Compatibility Reference](../get-started.md) page.
 
 However, there are a few prerequisites that a Scala 2.13 project must meet before being ported to Scala 3:
 - It must not depend on a macro library that has not yet been ported to Scala 3.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -8,7 +8,7 @@
       "compatibility/classpath": {
         "title": "Classpath Level"
       },
-      "compatibility/introduction": {
+      "get-started": {
         "title": "Introduction"
       },
       "compatibility/metaprogramming": {

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -83,7 +83,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle />
           <PromoSection>
-            <Button href={docUrl("compatibility/introduction.html", language)}>
+            <Button href={docUrl("get-started.html", language)}>
               Get started
             </Button>
           </PromoSection>
@@ -99,12 +99,12 @@ const Compatibility = () => (
       {
         content:
           'Scala 3 has been carefully designed to improve the backward and forward compatibility of the Scala programming language.\n\n' +
-          `In the [Compatibility Reference](${docUrl('compatibility/introduction.html')}) ` +
+          `In the [Compatibility Reference](${docUrl('get-started.html')}) ` +
           'you will learn about the compatibility between Scala 2.13 and Scala 3 in the context of the migration.',
         image: `${imgUrl('puzzle-primary.svg')}`,
         imageAlt: 'Icon made by Nikita Kozin from the Noun Project',
         imageAlign: 'left',
-        title: `[Compatibility](${docUrl('compatibility/introduction.html')})`,
+        title: `[Compatibility](${docUrl('get-started.html')})`,
       },
     ]}
   </Block>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Compatibility Reference": [
-      "compatibility/introduction",
+      "get-started",
       "compatibility/source",
       "compatibility/classpath",
       "compatibility/runtime",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -23,7 +23,7 @@ const siteConfig = {
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
-    {doc: 'compatibility/introduction', label: 'User Guide'},
+    {doc: 'get-started', label: 'User Guide'},
     {doc: 'contributing', label: 'Contribute'},
     { href: repoUrl, label: "GitHub", external: true }
   ],


### PR DESCRIPTION
The Algolia search index has not been updated for quite some time now.

This is probably caused by an outdated link in the [Algolia config](https://github.com/algolia/docsearch-configs/blob/master/configs/scala-3-migration-guide.json)

This PR attempts to fix it by reviving the "https://scalacenter.github.io/scala-3-migration-guide/docs/get-started.html" url.

Related issue: #174 