### PR TITLE
Add incompat: Inferred return type of an override method

### DIFF
--- a/docs/incompatibilities/incompatibility-table.md
+++ b/docs/incompatibilities/incompatibility-table.md
@@ -83,6 +83,7 @@ Some features are simplified or restricted to make the language easier and safer
 |[Invisible Bean Property](other-changed-features.md#invisible-bean-property)|||||
 |[Unsoundness fixes in variance checks](other-changed-features.md#unsoundness-fixes-in-variance-checks)|||||
 |[Unsoundness fixes in pattern matching](other-changed-features.md#unsoundness-fixes-in-pattern-matching)|||||
+|[Inferred return type of an override method](other-changed-features.md#inferred-return-type-of-an-override-method)|||||
 
 ### Implicit Resolution
 

--- a/docs/incompatibilities/other-changed-features.md
+++ b/docs/incompatibilities/other-changed-features.md
@@ -35,3 +35,6 @@ title: Other Changed Features
 
 ```scala mdoc:file:incompat-30/pattern-match/README.md
 ```
+
+```scala mdoc:file:incompat-30/infer-return-type/README.md
+```

--- a/incompat-30/infer-return-type/README.md
+++ b/incompat-30/infer-return-type/README.md
@@ -1,0 +1,45 @@
+## Inferred return type of an override method
+
+In Scala 2.13 the return type of an override method can be inferred from the left hand side, whereas in Scala 3 it would be inherited from the base method.
+
+```scala
+class Parent {
+  def foo: Foo = new Foo
+}
+
+class Child extends Parent {
+  override def foo = new RichFoo(super.foo)
+}
+```
+
+In this example, `Child#foo` returns a `RichFoo` in its Scala 2.13 signature but a `Foo` in its Scala 3 signature.
+It can lead to compiler errors as demonstrated below.
+
+```scala
+class Foo
+
+class RichFoo(foo: Foo) extends Foo {
+  def show: String = ""
+}
+
+class Parent {
+  def foo: Foo = new Foo
+}
+
+class Child extends Parent {
+  override def foo = new RichFoo(super.foo)
+}
+
+(new Child).foo.show // Scala 3 error: value show is not a member of Foo
+```
+
+In some rare cases involving implicit conversions and runtime casting it could even cause an runtime failure.
+
+The solution is to make the return type of the override method explicit:
+
+```diff
+class Child extends Parent {
+-  override def foo = new RichFoo(super.foo)
++  override def foo: RichFoo = new RichFoo(super.foo)
+}
+```

--- a/incompat-30/infer-return-type/src/main/scala-2.13/infer-return-type.scala
+++ b/incompat-30/infer-return-type/src/main/scala-2.13/infer-return-type.scala
@@ -1,0 +1,16 @@
+class Foo
+class RichFoo(foo: Foo) extends Foo {
+  def show: String = ""
+}
+
+class Parent {
+  def foo: Foo = new Foo
+}
+
+class Child extends Parent {
+  override def foo = new RichFoo(super.foo)
+}
+
+object Test {
+  (new Child).foo.show
+}

--- a/incompat-30/infer-return-type/src/main/scala/infer-return-type.scala
+++ b/incompat-30/infer-return-type/src/main/scala/infer-return-type.scala
@@ -1,0 +1,16 @@
+class Foo
+class RichFoo(foo: Foo) extends Foo {
+  def show: String = ""
+}
+
+class Parent {
+  def foo: Foo = new Foo
+}
+
+class Child extends Parent {
+  override def foo: RichFoo = new RichFoo(super.foo)
+}
+
+object Test {
+  (new Child).foo.show
+}

--- a/incompat.sbt
+++ b/incompat.sbt
@@ -121,7 +121,8 @@ lazy val otherIncompats = Seq[ProjectReference](
   viewBound,
   caseClassCompanion,
   patternMatch,
-  `bean-property`
+  `bean-property`,
+  `infer-return-type`
 )
 
 // Syntactic incompatibilities
@@ -144,6 +145,7 @@ lazy val reflectiveCall = project.in(file("incompat-30/reflective-call")).incomp
 lazy val caseClassCompanion = project.in(file("incompat-30/case-class-companion")).incompat30Settings
 lazy val patternMatch = project.in(file("incompat-30/pattern-match")).incompat30Settings
 lazy val `bean-property` = project.in(file("incompat-30/bean-property")).incompat30Settings
+lazy val `infer-return-type` = project.in(file("incompat-30/infer-return-type")).incompat30Settings
 
 // Contextual abstraction incompatibilities
 lazy val ambiguousConversion =

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -8,9 +8,6 @@
       "compatibility/classpath": {
         "title": "Classpath Level"
       },
-      "get-started": {
-        "title": "Introduction"
-      },
       "compatibility/metaprogramming": {
         "title": "Metaprogramming"
       },


### PR DESCRIPTION
Fixes #181 

```scala
class Foo

class RichFoo(foo: Foo) extends Foo {
  def show: String = ""
}

class Parent {
  def foo: Foo = new Foo
}

class Child extends Parent {
  override def foo = new RichFoo(super.foo)
}

object Test {
  (new Child).foo.show // Scala 3 error: value show is not a member of Foo
}
```

@smarter Is the Scala 3 behavior intentional?