### PR TITLE
Small typo fixed: Missing closing '}'

### DIFF
--- a/docs/tooling/scala-3-syntax-rewrites.md
+++ b/docs/tooling/scala-3-syntax-rewrites.md
@@ -95,6 +95,7 @@ case class State(n: Int, minValue: Int, maxValue: Int) {
       j <- 0 to n
     } println(i + j)
   }
+}
 ```
 
 Assume that we want to convert this piece of code to _SIB_ syntax & the new control syntax.


### PR DESCRIPTION
Small typo fixed: Missing closing '}'