### PR TITLE
Add kind-projector Migration Tutorial to sidebar index

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -71,6 +71,9 @@
       "tooling/scala-3-syntax-rewrites": {
         "title": "Scala 3 Syntax Rewriting"
       },
+      "tutorials/kind-projector": {
+        "title": "kind-projector Migration Tutorial"
+      },
       "tutorials/macro-cross-building": {
         "title": "Cross-Building a Macro Library"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,9 +16,9 @@
     "Tutorials": [
       "tutorials/prerequisites",
       "tutorials/sbt-migration",
+      "tutorials/kind-projector",
       "tutorials/macro-cross-building",
-      "tutorials/macro-mixing",
-      "tutorials/scalacoptions-migration"
+      "tutorials/macro-mixing"
     ],
     "Incompatibilities": [
       "incompatibilities/incompatibility-table",


### PR DESCRIPTION
@adpi2 Sorry, I forgot to add the page to sidebar so currently it's only accessible by URL. this fixes that